### PR TITLE
Make sure header file generated before including

### DIFF
--- a/panels/datetime/meson.build
+++ b/panels/datetime/meson.build
@@ -175,7 +175,8 @@ datetime_panel_lib = static_library(
 
 datetime_panel_dep = declare_dependency(
   include_directories: [ common_inc, include_directories('.') ],
-  link_with: datetime_panel_lib
+  link_with: datetime_panel_lib,
+  sources: resources
 )
 
 subdir('po-timezones')


### PR DESCRIPTION
It fails to compile xfce4-datetime-setter occasionally:

| ../git/panels/datetime/tz.c:34:10: fatal error: cc-datetime-resources.h: No such file or directory
|    34 | #include "cc-datetime-resources.h"
|       |          ^~~~~~~~~~~~~~~~~~~~~~~~~
| compilation terminated.

and

| ../git/xfce/main.c:42:10: fatal error: cc-datetime-resources.h: No such file or directory
|    42 | #include "cc-datetime-resources.h"
|       |          ^~~~~~~~~~~~~~~~~~~~~~~~~
| compilation terminated.

Update datetime_panel_dep to make sure cc-datetime-resources.h be generated
before including.

Signed-off-by: Kai Kang <kai.kang@windriver.com>